### PR TITLE
handle signals and rollback if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [unreleased]
 
+### Added
+
+- Support handling signals like `SIGINT` when interrupted with <kbd>^C</kbd>.
+  This will rollback any changes made so far when running the process in a
+  transaction. This rollback can be disabled with the new `--no-transaction`
+  option. ([#4])
+
+[#4]: https://github.com/club-1/flarum-ext-chore-commands/pull/4
+
 ## [v1.0.0] - 2023-05-03
 
 First stable release.


### PR DESCRIPTION
The whole process is now encapsulated in a transaction, allowing to use the database's rollback feature if the process is interrupted by a signal. For instance a SIGINT by Ctrl+C.

Each save is now done with saveOrFail() whith wraps the save() function in a transaction. But as SQL databases usually do not support nested transaction this is done using the SAVEPOINT feature by Laravel. See <https://github.com/laravel/framework/commit/9957329279fced0a24ac3d9d02cfe99407fa8f54>
